### PR TITLE
Fixed Angular2 issue with XMLHttpRequest

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,7 +19,7 @@
 #
 -->
 
-## v0.9.35 - April 27, 2016
+## v0.9.36 - April 27, 2016
 
 * Fix Angular 2 issue with XMLHttpRequest
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,10 @@
 #
 -->
 
+## v0.9.35 - April 27, 2016
+
+* Fix Angular 2 issue with XMLHttpRequest
+
 ## v0.9.35 - March 11, 2016
 
 * README was missing from package

--- a/lib/client/emulatorBridge.js
+++ b/lib/client/emulatorBridge.js
@@ -83,6 +83,9 @@ module.exports = {
                 get: function () {
                     return obj;
                 },
+                set: function (newValue) {
+                    obj = newValue;
+                },
                 configurable: existingDescriptor ? existingDescriptor.configurable : true,
                 enumerable: existingDescriptor ? existingDescriptor.enumerable : true
             });
@@ -91,6 +94,9 @@ module.exports = {
             Object.defineProperty(win, key, {
                 get: function () {
                     return obj;
+                },
+                set: function (newValue) {
+                    obj = newValue;
                 },
                 configurable: existingDescriptor ? existingDescriptor.configurable : true,
                 enumerable: existingDescriptor ? existingDescriptor.enumerable : true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-emulator",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "A browser based html5 mobile application development and testing tool",
   "homepage": "https://github.com/ripple-emulator/ripple",
   "author": {
@@ -37,7 +37,8 @@
     "express": "3.1.0",
     "moment": "1.x.x",
     "open": "0.0.3",
-    "request": "2.12.0"
+    "request": "2.12.0", 
+    "buffer-crc32": "0.2.5"
   },
   "devDependencies": {
     "bower": "1.3.12",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "express": "3.1.0",
     "moment": "1.x.x",
     "open": "0.0.3",
-    "request": "2.12.0", 
-    "buffer-crc32": "0.2.5"
+    "request": "2.12.0"
   },
   "devDependencies": {
     "bower": "1.3.12",
@@ -51,7 +50,8 @@
     "q": "^1.4.1",
     "semver": "^4.3.1",
     "shelljs": "^0.4.0",
-    "xmlhttprequest": "1.4.2"
+    "xmlhttprequest": "1.4.2", 
+    "buffer-crc32": "0.2.5"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
This PR fixes the problems users are running into when using Angular 2 with Ripple, with Angular 2 complaining about not being able to set the XMLHttpRequest property.
The fix adds a setter to the definition of the XMLHttpRequest property through Object.defineProperty. 