### PR TITLE
Release 0.9.36

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,10 @@
 #
 -->
 
+## v0.9.36 - May 4, 2016
+
+* Fix Angular 2 issue with XMLHttpRequest
+
 ## v0.9.35 - March 11, 2016
 
 * README was missing from package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-emulator",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "A browser based html5 mobile application development and testing tool",
   "homepage": "https://github.com/ripple-emulator/ripple",
   "author": {
@@ -50,7 +50,8 @@
     "q": "^1.4.1",
     "semver": "^4.3.1",
     "shelljs": "^0.4.0",
-    "xmlhttprequest": "1.4.2"
+    "xmlhttprequest": "1.4.2",
+    "buffer-crc32": "0.2.5"
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "q": "^1.4.1",
     "semver": "^4.3.1",
     "shelljs": "^0.4.0",
-    "xmlhttprequest": "1.4.2",
-    "buffer-crc32": "0.2.5"
+    "xmlhttprequest": "1.4.2"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
This release of Ripple fixes a bug that has prevented it from working with Angular 2. 
