### PR TITLE
Support new androic project structure

### DIFF
--- a/lib/server/emulate/cordovaProject.js
+++ b/lib/server/emulate/cordovaProject.js
@@ -31,7 +31,11 @@ function buildPaths(opts) {
         var platforms = fs.readdirSync(path.join(paths.orig, "platforms"));
         if (platforms.indexOf('android') >= 0) {
             opts.cordova = 'android';
-            paths.android = path.join(paths.orig, "platforms", "android", "assets", "www");
+            if(fs.existsSync(path.join(paths.orig, "platforms", "android", "app", "src", "main", "assets", "www"))) {
+                paths.android = path.join(paths.orig, "platforms", "android", "app", "src", "main", "assets", "www");
+            } else {
+                paths.android = path.join(paths.orig, "platforms", "android", "assets", "www");
+            }
         }
 
         if (platforms.indexOf('ios') >= 0) {
@@ -50,6 +54,8 @@ function buildPaths(opts) {
         }
     }
 
+    // we need these paths later on as wekl
+    opts.paths = paths;
     return paths;
 }
 

--- a/lib/server/emulate/hosted.js
+++ b/lib/server/emulate/hosted.js
@@ -122,7 +122,7 @@ function remoteInjection(opts) {
     };
 }
 
-function localInjection() {
+function localInjection(opts) {
 
     function inject(file, req, res) {
         fs.readFile(file, "utf-8", function (err, data) {
@@ -165,7 +165,7 @@ function localInjection() {
         // as of version 3.0 phonegap uses phonegap.js instead of cordova.js
         // but the files are identical
         if (req.query.phonegap) {
-            var path = './platforms/' + req.staticPlatform + '/assets/www';
+            var path = opts.paths[opts.cordova];
             fs.readFile(path + '/cordova.js', function(err, data) {
                 if(err) throw err;
                 console.log('... copying cordova.js to phonegap.js');


### PR DESCRIPTION
Cordova >=7 uses the new project structure of android. Therefore the assets could not be found anymore.